### PR TITLE
ci: migrate to goreleaser Gen 2 (PLA-461)

### DIFF
--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -1,0 +1,26 @@
+---
+name: GoReleaser config check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - .goreleaser.yaml
+  workflow_dispatch:
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+
+      - name: goreleaser check
+        run: goreleaser check

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,35 @@
+# .goreleaser.yaml for rpcpool/yellowstone-thorofare
+#
+# This file must be committed to the root of the yellowstone-thorofare source
+# repo. GCS upload, cosigning, and GitHub Release publishing are injected via
+# ci/goreleaser-patch.yaml in Binaries-ci at build time.
+#
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+builds:
+    - id: thorofare
+      builder: rust
+      binary: thorofare
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=thorofare
+
+archives:
+    - formats: [binary]
+      name_template: yellowstone-thorofare-linux-amd64
+
+release:
+    github:
+        owner: rpcpool
+        name: yellowstone-thorofare
+    draft: true
+    header: |
+        rust {{ .Env.RUST_VERSION }}
+
+changelog:
+    sort: asc
+    use: github


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yaml` — single `thorofare` binary for `x86_64-unknown-linux-gnu`, archive `yellowstone-thorofare-linux-amd64`
- Add `.github/workflows/goreleaser-config-check.yaml` — validates config on PRs (GitHub-hosted runner, public repo)
- GCS upload, cosigning, and Slack notification injected via `ci/goreleaser-patch.yaml` in Binaries-ci at build time

**GCS path change:** Gen 1 uploads to `nomad-triton-test/thorofare/<commit>/`; Gen 2 will use `nomad-triton-test/yellowstone-thorofare/v<semver>/`. Downstream consumers in nomad/terraform need updating before cutover.

**Companion PR:** Binaries-ci PR removes `solana_yellowstone_thorofare-release.yml` and `ci/solana/yellowstone-thorofare-ref.txt`.

**Merge order:** Merge this PR first, then the Binaries-ci cleanup PR.

Part of PLA-412 / PLA-461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)